### PR TITLE
Create no-await-outside-steps Eslint Rule

### DIFF
--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -3,5 +3,6 @@ export const recommended = {
     "@inngest/await-inngest-send": "warn",
     "@inngest/no-nested-steps": "error",
     "@inngest/no-variable-mutation-in-step": "error",
+    "@inngest/no-await-outside-step": "error",
   },
 };

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -2,9 +2,11 @@ import { TSESLint } from "@typescript-eslint/utils";
 import { awaitInngestSend } from "./await-inngest-send";
 import { noNestedSteps } from "./no-nested-steps";
 import { noVariableMutationInStep } from "./no-variable-mutation-in-step";
+import { noAwaitOutsideSteps } from "./no-await-outside-step";
 
 export const rules = {
   "await-inngest-send": awaitInngestSend,
   "no-nested-steps": noNestedSteps,
   "no-variable-mutation-in-step": noVariableMutationInStep,
+  "no-await-outside-steps": noAwaitOutsideSteps,
 } satisfies Record<string, TSESLint.RuleModule<string, Array<unknown>>>;

--- a/packages/eslint-plugin/src/rules/no-await-outside-step.test.ts
+++ b/packages/eslint-plugin/src/rules/no-await-outside-step.test.ts
@@ -1,0 +1,191 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { noAwaitOutsideSteps } from "./no-await-outside-step";
+
+const ruleTester = new RuleTester({
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+});
+
+ruleTester.run("no-await-outside-steps", noAwaitOutsideSteps, {
+  valid: [
+    // Non-Inngest functions (no 'step' param) - should ignore
+    `async function regularFunction() {
+      const data = await fetch('https://api.example.com');
+      return data;
+    }`,
+
+    // Proper step usage in Inngest function
+    `const myFunction = inngest.createFunction(
+      { id: 'test' },
+      { event: 'test.event' },
+      async ({ event, step }) => {
+        const data = await step.run('fetch-data', async () => {
+          const result = await fetch('https://api.example.com');
+          return await result.json();
+        });
+        return { success: true, data };
+      }
+    )`,
+
+    // Multiple step.run calls, properly using await inside callbacks
+    `async function handler({ step }) {
+      const a = await step.run("step-a", async () => {
+        const data = await fetch('/api/a');
+        return data;
+      });
+      
+      const b = await step.run("step-b", async () => {
+        const data = await fetch('/api/b');
+        return data;
+      });
+      
+      return { a, b };
+    }`,
+
+    // Other step functions (not just run)
+    `async function handler({ step }) {
+      const result = await step.waitForEvent("wait-for-event", { event: "user.created" });
+      
+      await step.sleep("wait-a-bit", "1h");
+      
+      await step.invoke("do-things", {
+        first: async () => {
+          const data = await fetch('/api');
+          return data;
+        }
+      });
+      
+      return { success: true };
+    }`,
+
+    // Test for step.sleepUntil
+    `async function handler({ step }) {
+      await step.sleepUntil("wait-until-timestamp", new Date("2023-12-31"));
+      
+      await step.sleepUntil("wait-with-callback", async () => {
+        const targetDate = await fetchTargetDate();
+        return new Date(targetDate);
+      });
+      
+      return { success: true };
+    }`,
+
+    // More comprehensive test for step.invoke
+    `async function handler({ step }) {
+      // Simple invoke
+      await step.invoke("invoke-function", "my.function");
+      
+      // Invoke with data
+      await step.invoke("invoke-with-data", "process.order", { orderId: "123" });
+      
+      // Invoke with callback for data
+      await step.invoke("invoke-with-callback", "analyze", async () => {
+        const data = await fetchAnalysisData();
+        return { analysisData: data };
+      });
+      
+      return { success: true };
+    }`,
+
+    // Test for step.waitForEvent
+    `async function handler({ step }) {
+      const event = await step.waitForEvent("wait-for-user-login", { 
+        event: "user.login",
+        match: { userId: "123" }
+      });
+      
+      // With timeout
+      const paymentEvent = await step.waitForEvent("wait-for-payment", {
+        event: "payment.processed",
+        timeout: "10m",
+        match: async () => {
+          const criteria = await fetchMatchCriteria();
+          return criteria;
+        }
+      });
+      
+      return { received: true };
+    }`,
+  ],
+
+  invalid: [
+    // Basic case: await directly in handler
+    {
+      code: `async function handler({ step }) {
+        const data = await fetch('https://api.example.com');
+        return data;
+      }`,
+      errors: [{ messageId: "no-await-outside-steps" }],
+    },
+
+    // Multiple awaits outside steps
+    {
+      code: `async function processOrder({ step }) {
+        const order = await fetchOrder();
+        const user = await fetchUser();
+        
+        return await step.run("process", async () => {
+          // This await is fine
+          return await processData(order, user);
+        });
+      }`,
+      errors: [
+        { messageId: "no-await-outside-steps" },
+        { messageId: "no-await-outside-steps" },
+      ],
+    },
+
+    // Using await in return statement outside step
+    {
+      code: `const myFunction = inngest.createFunction(
+        { id: 'test' },
+        { event: 'test.event' },
+        async ({ step }) => {
+          const id = step.run("get-id", () => "123");
+          return await getResult(id);
+        }
+      )`,
+      errors: [{ messageId: "no-await-outside-steps" }],
+    },
+
+    // Mix of valid and invalid awaits
+    {
+      code: `async function handler({ event, step }) {
+        // Invalid - outside step
+        const config = await getConfig();
+        
+        // Valid - inside step.run
+        const user = await step.run("get-user", async () => {
+          return await fetchUser(event.userId);
+        });
+        
+        // Invalid - outside step
+        const permissions = await getPermissions(user.id);
+        
+        return { user, permissions };
+      }`,
+      errors: [
+        { messageId: "no-await-outside-steps" },
+        { messageId: "no-await-outside-steps" },
+      ],
+    },
+
+    // Object destructuring for step
+    {
+      code: `async ({ 
+        step,
+        event 
+      }) => {
+        const data = await fetch('/api/data');
+        await step.run("process", () => {
+          // Valid await inside step
+          return Promise.resolve(data);
+        });
+      }`,
+      errors: [{ messageId: "no-await-outside-steps" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/no-await-outside-step.ts
+++ b/packages/eslint-plugin/src/rules/no-await-outside-step.ts
@@ -1,0 +1,167 @@
+import { AST_NODE_TYPES, TSESLint, TSESTree } from "@typescript-eslint/utils";
+
+export const noAwaitOutsideSteps: TSESLint.RuleModule<"no-await-outside-steps"> =
+  {
+    meta: {
+      type: "problem",
+      docs: {
+        description:
+          "disallow use of `await` outside of `step.run()` callbacks in Inngest functions",
+        recommended: "recommended",
+      },
+      schema: [], // no options
+      messages: {
+        "no-await-outside-steps":
+          "Use of `await` is only allowed within step function callbacks in Inngest functions",
+      },
+    },
+    defaultOptions: [],
+    create(context: TSESLint.RuleContext<"no-await-outside-steps", []>) {
+      // Track function scopes with minimal data that won't create circular references
+      const functionScopes = new Map<
+        string,
+        { isInngestHandler: boolean; stepRunStack: number }
+      >();
+
+      // Generate a unique key for a function node
+      function getFunctionKey(node: TSESTree.FunctionLike): string {
+        // Use node.range if available, otherwise create a key from the node's start/end location
+        if (node.range) {
+          return `${node.range[0]}-${node.range[1]}`;
+        }
+        const loc = node.loc;
+        return loc
+          ? `${loc.start.line}:${loc.start.column}-${loc.end.line}:${loc.end.column}`
+          : "unknown";
+      }
+
+      // Find parent function without storing node references
+      function findParentFunction(
+        node: TSESTree.Node,
+      ): { key: string; node: TSESTree.FunctionLike } | null {
+        let current = node.parent;
+        while (current) {
+          if (
+            current.type === AST_NODE_TYPES.FunctionDeclaration ||
+            current.type === AST_NODE_TYPES.FunctionExpression ||
+            current.type === AST_NODE_TYPES.ArrowFunctionExpression
+          ) {
+            return {
+              key: getFunctionKey(current),
+              node: current,
+            };
+          }
+          current = current.parent;
+        }
+        return null;
+      }
+
+      // Check if node is a step function call (step.run, step.waitFor, etc)
+      function isStepFunctionCall(node: TSESTree.Node): boolean {
+        return (
+          node.type === AST_NODE_TYPES.CallExpression &&
+          node.callee.type === AST_NODE_TYPES.MemberExpression &&
+          node.callee.object.type === AST_NODE_TYPES.Identifier &&
+          node.callee.object.name === "step" &&
+          node.callee.property.type === AST_NODE_TYPES.Identifier &&
+          [
+            "run",
+            "sleep",
+            "sleepUntil",
+            "invoke",
+            "waitForEvent",
+            "sendEvent",
+          ].includes(node.callee.property.name)
+        );
+      }
+
+      return {
+        // Identify potential Inngest handler functions
+        "FunctionDeclaration, FunctionExpression, ArrowFunctionExpression"(
+          node:
+            | TSESTree.FunctionDeclaration
+            | TSESTree.FunctionExpression
+            | TSESTree.ArrowFunctionExpression,
+        ) {
+          // Check if function has a parameter named 'step' or has destructuring that includes 'step'
+          const hasStepParam = node.params.some((param) => {
+            if (param.type === AST_NODE_TYPES.Identifier) {
+              return param.name === "step";
+            } else if (param.type === AST_NODE_TYPES.ObjectPattern) {
+              return param.properties.some(
+                (prop) =>
+                  prop.type === AST_NODE_TYPES.Property &&
+                  prop.key.type === AST_NODE_TYPES.Identifier &&
+                  prop.key.name === "step",
+              );
+            }
+            return false;
+          });
+
+          const isInngestHandler = hasStepParam && node.async;
+          functionScopes.set(getFunctionKey(node), {
+            isInngestHandler,
+            stepRunStack: 0,
+          });
+        },
+
+        // Track step function calls
+        CallExpression(node) {
+          if (isStepFunctionCall(node)) {
+            const parentFunc = findParentFunction(node);
+            if (parentFunc) {
+              const scopeInfo = functionScopes.get(parentFunc.key);
+              if (scopeInfo) {
+                scopeInfo.stepRunStack += 1;
+                functionScopes.set(parentFunc.key, scopeInfo);
+              }
+            }
+          }
+        },
+
+        "CallExpression:exit"(node) {
+          if (isStepFunctionCall(node)) {
+            const parentFunc = findParentFunction(node);
+            if (parentFunc) {
+              const scopeInfo = functionScopes.get(parentFunc.key);
+              if (scopeInfo) {
+                scopeInfo.stepRunStack = Math.max(
+                  0,
+                  scopeInfo.stepRunStack - 1,
+                );
+                functionScopes.set(parentFunc.key, scopeInfo);
+              }
+            }
+          }
+        },
+
+        // Check await expressions
+        AwaitExpression(node) {
+          // Allow await if it's directly awaiting a step function call
+          if (isStepFunctionCall(node.argument)) {
+            return;
+          }
+
+          const parentFunc = findParentFunction(node);
+          if (parentFunc) {
+            const scopeInfo = functionScopes.get(parentFunc.key);
+            if (
+              scopeInfo &&
+              scopeInfo.isInngestHandler &&
+              scopeInfo.stepRunStack === 0
+            ) {
+              context.report({
+                node,
+                messageId: "no-await-outside-steps",
+              });
+            }
+          }
+        },
+
+        // Clean up function scopes
+        "Program:exit"() {
+          functionScopes.clear();
+        },
+      };
+    },
+  };


### PR DESCRIPTION
## Summary

I recently ran into a tricky bug with Inngest that was a result of accidentally having an `await` call outside of an inngest step.

To hopefully solve this issue moving forward, I figured it would be useful to create an eslint rule that could surface these issues.


## Checklist
- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

